### PR TITLE
Add ScheduleTag component.

### DIFF
--- a/ScheduleTag/index.jsx
+++ b/ScheduleTag/index.jsx
@@ -1,0 +1,18 @@
+import React, { PropTypes } from 'react';
+import styles from './style.css';
+
+const ScheduleTag = ({ dateString }) => {
+  return (
+    <span className={styles.scheduleTag}>
+        {dateString}
+        <span className={styles.arrow}>
+        </span>
+    </span>
+  );
+};
+
+ScheduleTag.propTypes = {
+  dateString: PropTypes.string.isRequired,
+};
+
+export default ScheduleTag;

--- a/ScheduleTag/story.jsx
+++ b/ScheduleTag/story.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { storiesOf } from '@kadira/storybook';
+import ScheduleTag from './index';
+
+const date = '08:52am (GMC)';
+
+storiesOf('ScheduleTag')
+  .add('Default', () => (
+    <ScheduleTag dateString={date}></ScheduleTag>
+  ))
+  

--- a/ScheduleTag/style.css
+++ b/ScheduleTag/style.css
@@ -1,0 +1,25 @@
+@import '../layout.css';
+@import '../variables.css';
+
+.scheduleTag {
+    position: relative;
+    background-color: var(--curious-blue);
+    font-size: 11px;
+    color: var(--white);
+    height: 24px;
+    padding-left: 8px;
+    padding-right: 2px;
+    display: inline-block;
+    line-height: 24px;
+    border-radius: 2px 0 0 2px;
+}
+
+.arrow {
+    position: absolute;
+    right: -12px;
+    width: 0;
+    height: 0;
+    border-top: 12px solid transparent;
+    border-bottom: 12px solid transparent;
+    border-left: 12px solid var(--curious-blue);
+}

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -471,6 +471,15 @@ exports[`Snapshots NavBar Subtitle 1`] = `
 </div>
 `;
 
+exports[`Snapshots ScheduleTag Default 1`] = `
+<span
+  className="scheduleTag">
+  08:52am (GMC)
+  <span
+    className="arrow" />
+</span>
+`;
+
 exports[`Snapshots Text Bold 1`] = `
 <span
   className="text bold">


### PR DESCRIPTION
Add ScheduleTag component.

@stevemdixon and I worked on this today and a came across a couple of areas that we had questions on. 

It doesn't feel great to set the tag copy directly but not sure it feels great to add logic to the component, either. 
For example, if we want to set the PropType to ensure we're only receiving date objects - then we'd have to do the conversion to string in the component itself. 
Since we want to show a slightly different copy depending on whether the tag is in the timeline or in the 'For Review' tab (just time vs day/month + time), we'd have to pass in a flag to let the component know which copy we want.

For now, we just have the copy set directly to keep the component clean and simple and just have an isRequired check for the string - since the tag can't be empty. Happy to revisit if this doesn't feel like the right path.