### PR TITLE
Minor/update loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.13 (January 10, 2017)
+
+- Added `withText` config to `Loader` to display with `Text`
+- Updated default config of `Loader` to display without text
+
 ## 0.1.3 (January 10, 2017)
 
 - Removed component dependency on `typography.css`

--- a/Loader/index.jsx
+++ b/Loader/index.jsx
@@ -3,6 +3,14 @@ import Icon from '../Icon';
 import Text from '../Text';
 import styles from './style.css';
 
+const renderText = (children) => {
+  if (children) {
+    return (
+      <Text>{children}</Text>
+    );
+  }
+};
+
 const Loader = ({ children }) =>
   <div className={styles.loader}>
     <div className={styles.icon}>
@@ -10,7 +18,7 @@ const Loader = ({ children }) =>
       <Icon type={'buffer-middle'} className={styles.middle} />
       <Icon type={'buffer-bottom'} className={styles.bottom} />
     </div>
-    <Text>{children}</Text>
+    { renderText(children) }
   </div>;
 
 Loader.propTypes = {

--- a/Loader/index.jsx
+++ b/Loader/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { classNames } from '../lib/utils';
 import Icon from '../Icon';
+import Text from '../Text';
 import styles from './style.css';
 
 const Loader = ({ children }) => {
@@ -12,7 +13,7 @@ const Loader = ({ children }) => {
         <Icon type={'buffer-middle'} className={styles.middle} />
         <Icon type={'buffer-bottom'} className={styles.bottom} />
       </div>
-      <p className={styles.content}>{children}</p>
+      <Text>{children}</Text>
     </div>
   );
 };

--- a/Loader/index.jsx
+++ b/Loader/index.jsx
@@ -1,22 +1,17 @@
 import React, { PropTypes } from 'react';
-import { classNames } from '../lib/utils';
 import Icon from '../Icon';
 import Text from '../Text';
 import styles from './style.css';
 
-const Loader = ({ children }) => {
-  const classes = classNames(styles, 'loader');
-  return (
-    <div className={classes}>
-      <div className={styles.icon}>
-        <Icon type={'buffer-top'} className={styles.top} />
-        <Icon type={'buffer-middle'} className={styles.middle} />
-        <Icon type={'buffer-bottom'} className={styles.bottom} />
-      </div>
-      <Text>{children}</Text>
+const Loader = ({ children }) =>
+  <div className={styles.loader}>
+    <div className={styles.icon}>
+      <Icon type={'buffer-top'} className={styles.top} />
+      <Icon type={'buffer-middle'} className={styles.middle} />
+      <Icon type={'buffer-bottom'} className={styles.bottom} />
     </div>
-  );
-};
+    <Text>{children}</Text>
+  </div>;
 
 Loader.propTypes = {
   children: PropTypes.node,

--- a/Loader/story.jsx
+++ b/Loader/story.jsx
@@ -3,6 +3,9 @@ import { storiesOf } from '@kadira/storybook';
 import Loader from './index';
 
 storiesOf('Loader')
-  .add('Default', () => (
+  .add('default', () => (
+    <Loader />
+  ))
+  .add('withText', () => (
     <Loader>Some neat loading text!</Loader>
   ));

--- a/Loader/style.css
+++ b/Loader/style.css
@@ -7,7 +7,7 @@
 
 .icon {
   position: relative;
-  margin: 0 auto;
+  margin: 0 auto 1em auto;
   width: 1.5em;
   height: 1.5em;
 }
@@ -46,12 +46,4 @@
   top: 0;
   left: 0;
   font-size: 1.5em;
-}
-
-.content {
-  margin-top: 1em;
-  width: 100%;
-  font-size: var(--font-size);
-  line-height: var(--line-height);
-  color: var(--shuttle-gray);
 }

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -420,7 +420,7 @@ exports[`Snapshots LinkifiedText two links 1`] = `
 </span>
 `;
 
-exports[`Snapshots Loader Default 1`] = `
+exports[`Snapshots Loader default 1`] = `
 <div
   className="loader">
   <div
@@ -432,10 +432,25 @@ exports[`Snapshots Loader Default 1`] = `
     <i
       className="icon bottom bi bi-buffer-bottom" />
   </div>
-  <p
-    className="content">
+</div>
+`;
+
+exports[`Snapshots Loader withText 1`] = `
+<div
+  className="loader">
+  <div
+    className="icon">
+    <i
+      className="icon top bi bi-buffer-top" />
+    <i
+      className="icon middle bi bi-buffer-middle" />
+    <i
+      className="icon bottom bi bi-buffer-bottom" />
+  </div>
+  <span
+    className="text">
     Some neat loading text!
-  </p>
+  </span>
 </div>
 `;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.1.7",
+  "version": "0.1.13",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Purpose
This is a minor update to our `Loader` component, which switches the `p` element we use to wrap around our `children` prop with the `Text` component.
### Things to Note
This change has cleaned this component up a little and we've been able to remove the `.content` CSS class completely as this styling is handled by the `Text` component. The margin/space between the icon and the `Text` component is handled by the `.icon` class.
### Review
Would love to see if I've covered all the bases here!
