### PR TITLE
Adjust extra-small font config in Text Component

### DIFF
--- a/Text/index.jsx
+++ b/Text/index.jsx
@@ -2,13 +2,14 @@ import React, { PropTypes } from 'react';
 import { classNames } from '../lib/utils';
 import styles from './style.css';
 
-const Text = ({ children, size, weight }) => {
+const Text = ({ children, size, weight, color }) => {
   const classes = classNames(styles, 'text', {
     extraSmall: size === 'extra-small',
     small: size === 'small',
     large: size === 'large',
     thin: weight === 'thin',
     bold: weight === 'bold',
+    white: color === 'white',
   });
   return (
     <span className={classes}>{children}</span>
@@ -17,8 +18,9 @@ const Text = ({ children, size, weight }) => {
 
 Text.propTypes = {
   children: PropTypes.node,
-  size: PropTypes.oneOf(['large', 'small']),
+  size: PropTypes.oneOf(['large', 'small', 'extra-small']),
   weight: PropTypes.oneOf(['bold', 'thin']),
+  color: PropTypes.oneOf(['white']),
 };
 
 export default Text;

--- a/Text/story.jsx
+++ b/Text/story.jsx
@@ -22,4 +22,8 @@ storiesOf('Text')
   ))
   .add('Thin', () => (
     <Text weight={'thin'}>{text}</Text>
+  ))
+  .add('White', () => (
+    <Text color={'white'}>{text}</Text>
   ));
+

--- a/Text/style.css
+++ b/Text/style.css
@@ -27,3 +27,7 @@
 .bold {
   font-weight: var(--font-weight-bold);
 }
+
+.white {
+  color: var(--white);
+}

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -513,6 +513,13 @@ exports[`Snapshots Text Thin 1`] = `
 </span>
 `;
 
+exports[`Snapshots Text White 1`] = `
+<span
+  className="text white">
+  The quick brown fox jumps over the lazy dog
+</span>
+`;
+
 exports[`Snapshots Video Default 1`] = `
 <video
   className=""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.1.8",
+  "version": "0.1.8-beta-1",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {

--- a/variables.css
+++ b/variables.css
@@ -31,7 +31,7 @@
   --font-size: 1em;
   --font-size-large: 2em;
   --font-size-small: 0.9em;
-  --font-size-extra-small: 0.8em;
+  --font-size-extra-small: 0.7em;
   --font-weight-bold: 600;
   --font-weight: 400;
   --font-weight-thin: 300;


### PR DESCRIPTION
The extra-small configuration for the text component was a bit too small - updated font-size to 0.7 em.
Added font color configuration to the text component. This is limited to the default of gray and input of white for now. We can add specific buffer colors as we need them.
Added inheriting of font-size to the button component noStyle configuration.
Bumped up to the next version. 