### PR TITLE
Add Overlay component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log*
 node_modules
 .npm
 /coverage
+.DS_Store

--- a/Overlay/index.jsx
+++ b/Overlay/index.jsx
@@ -1,7 +1,9 @@
 import React, { PropTypes } from 'react';
 import styles from './style.css';
 
-const Overlay = ({ onClick }) => <div className={styles.overlay} onClick={onClick} />;
+const Overlay = ({ onClick }) =>
+  // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+  <div className={styles.overlay} onClick={onClick} />;
 
 Overlay.propTypes = {
   onClick: PropTypes.func,

--- a/Overlay/index.jsx
+++ b/Overlay/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import styles from './style.css';
+
+const Overlay = () => <div className={styles.overlay} />;
+
+export default Overlay;

--- a/Overlay/index.jsx
+++ b/Overlay/index.jsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import styles from './style.css';
 
-const Overlay = () => <div className={styles.overlay} />;
+const Overlay = ({ onClick }) => <div className={styles.overlay} onClick={onClick} />;
+
+Overlay.propTypes = {
+  onClick: PropTypes.func,
+};
 
 export default Overlay;

--- a/Overlay/story.jsx
+++ b/Overlay/story.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { storiesOf } from '@kadira/storybook';
+import Overlay from './index';
+import Button from '../Button/index';
+
+storiesOf('Overlay')
+  .add('default', () => (
+    <Overlay>
+      <Button>Test</Button>
+    </Overlay>
+  ));

--- a/Overlay/story.jsx
+++ b/Overlay/story.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import Overlay from './index';
-import Button from '../Button/index';
 
 storiesOf('Overlay')
   .add('default', () => (
-    <Overlay>
-      <Button>Test</Button>
-    </Overlay>
+    <Overlay />
   ));

--- a/Overlay/story.jsx
+++ b/Overlay/story.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { storiesOf } from '@kadira/storybook';
+import { storiesOf, action } from '@kadira/storybook';
 import Overlay from './index';
+import Image from '../Image';
 
 storiesOf('Overlay')
   .add('default', () => (
-    <Overlay />
+    <div style={{ textAlign: 'center' }}>
+      <Image src={'http://lorempixel.com/400/400/cats/'} />
+      <Overlay onClick={action('overlay-click')} />
+    </div>
   ));

--- a/Overlay/style.css
+++ b/Overlay/style.css
@@ -1,7 +1,7 @@
 @import '../variables.css';
 
 .overlay {
-  position: absolute;;
+  position: absolute;
   top: 0;
   right: 0;
   bottom: 0;

--- a/Overlay/style.css
+++ b/Overlay/style.css
@@ -1,12 +1,13 @@
 @import '../variables.css';
 
 .overlay {
-  position: fixed;
+  position: absolute;;
   top: 0;
+  right: 0;
+  bottom: 0;
   left: 0;
   width: 100%;
   height: 100%;
   background-color: var(--outer-space-ultra-dark);
-  overflow-x: hidden;
   z-index: 25;
 }

--- a/Overlay/style.css
+++ b/Overlay/style.css
@@ -9,5 +9,5 @@
   width: 100%;
   height: 100%;
   background-color: var(--outer-space-ultra-dark);
-  z-index: 25;
+  z-index: var(--overlay);
 }

--- a/Overlay/style.css
+++ b/Overlay/style.css
@@ -6,8 +6,6 @@
   right: 0;
   bottom: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
   background-color: var(--outer-space-ultra-dark);
   z-index: var(--overlay);
 }

--- a/Overlay/style.css
+++ b/Overlay/style.css
@@ -1,0 +1,12 @@
+@import '../variables.css';
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--outer-space);
+  overflow-x: hidden;
+  z-index: 25;
+}

--- a/Overlay/style.css
+++ b/Overlay/style.css
@@ -6,7 +6,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: var(--outer-space);
+  background-color: var(--outer-space-ultra-dark);
   overflow-x: hidden;
   z-index: 25;
 }

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -2339,6 +2339,12 @@ exports[`Snapshots NavBar Subtitle 1`] = `
 </div>
 `;
 
+exports[`Snapshots Overlay default 1`] = `
+<div
+  className="overlay"
+  onClick={undefined} />
+`;
+
 exports[`Snapshots Text Bold 1`] = `
 <span
   className="text bold">

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -2341,8 +2341,30 @@ exports[`Snapshots NavBar Subtitle 1`] = `
 
 exports[`Snapshots Overlay default 1`] = `
 <div
-  className="overlay"
-  onClick={undefined} />
+  style={
+    Object {
+      "textAlign": "center",
+    }
+  }>
+  <img
+    alt="Image"
+    className=""
+    src="http://lorempixel.com/400/400/cats/"
+    style={
+      Object {
+        "height": undefined,
+        "maxHeight": undefined,
+        "maxWidth": undefined,
+        "minHeight": undefined,
+        "minWidth": undefined,
+        "objectFit": undefined,
+        "width": undefined,
+      }
+    } />
+  <div
+    className="overlay"
+    onClick={[Function]} />
+</div>
 `;
 
 exports[`Snapshots Text Bold 1`] = `

--- a/variables-colors.css
+++ b/variables-colors.css
@@ -13,6 +13,7 @@
   --twitter: #55acee;
 
   --outer-space: #323b43;
+  --outer-space-ultra-dark: rgba(50, 59, 67, 0.8);
   --outer-space-light: rgba(50, 59, 67, 0.3);
   --outer-space-ultra-light: rgba(50, 59, 67, 0.1);
   --shuttle-gray: #59626a;


### PR DESCRIPTION
### Purpose
This PR resolves #32 by adding an `Overlay` component that we will use to compose UI that is designed to appear to "sit above" other UI i.e. modals.
### Things to Note
`Overlay` has an `onClick` prop that can be used as part of a "close" UX.
### Review
Keen to see how this feels for y'all! 👍