### PR TITLE
Minor/add unstyled config to link component

### DIFF
--- a/Link/index.jsx
+++ b/Link/index.jsx
@@ -1,11 +1,27 @@
 import React, { PropTypes } from 'react';
+import { classNames } from '../lib/utils';
 import styles from './style.css';
 
-const Link = ({ children, href }) => <a className={styles.link} href={href}>{children}</a>;
+const Link = ({
+  children,
+  href,
+  unstyled
+}) => {
+  const classes = classNames(styles, 'link', {
+    unstyled,
+  });
+
+  return (
+    <a className={classes} href={href}>
+      {children}
+    </a>
+  );
+}
 
 Link.propTypes = {
   children: PropTypes.string,
   href: PropTypes.string,
+  unstyled: PropTypes.bool,
 };
 
 export default Link;

--- a/Link/story.jsx
+++ b/Link/story.jsx
@@ -9,4 +9,11 @@ storiesOf('Link')
       <br />
       <Link href={'https://buffer.com'}>Buffer</Link>
     </div>
+  ))
+  .add('unstyled', () => (
+    <div>
+      <Link href={'https://twitter.com'} unstyled>Twitter</Link>
+      <br />
+      <Link href={'https://buffer.com'} unstyled>Buffer</Link>
+    </div>
   ));

--- a/Link/style.css
+++ b/Link/style.css
@@ -16,3 +16,7 @@
 .link:active {
   color: var(--tory-blue);
 }
+
+.unstyled {
+  text-decoration: none;
+}

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -646,6 +646,22 @@ exports[`Snapshots Link Default 1`] = `
 </div>
 `;
 
+exports[`Snapshots Link unstyled 1`] = `
+<div>
+  <a
+    className="link unstyled"
+    href="https://twitter.com">
+    Twitter
+  </a>
+  <br />
+  <a
+    className="link unstyled"
+    href="https://buffer.com">
+    Buffer
+  </a>
+</div>
+`;
+
 exports[`Snapshots LinkifiedText default 1`] = `
 <span
   className="text">


### PR DESCRIPTION
Adding an 'unstyled'  config option for the Link component - removes  link text-decoration.
Will update version to 0.1.20 in separate PR. 