### PR TITLE
Update propType to node

### DIFF
--- a/Link/index.jsx
+++ b/Link/index.jsx
@@ -19,7 +19,7 @@ const Link = ({
 }
 
 Link.propTypes = {
-  children: PropTypes.string,
+  children: PropTypes.node,
   href: PropTypes.string,
   unstyled: PropTypes.bool,
 };


### PR DESCRIPTION
Updates Link proptype to node to prevent error when passing in elements. 
Fixes error in LinkPost
![image](https://cloud.githubusercontent.com/assets/6446462/23070170/7789f9b6-f52a-11e6-92e3-3e9eefb68e5b.png)
