### PR TITLE
Patch Button by removing default margin

### DIFF
--- a/Button/style.css
+++ b/Button/style.css
@@ -2,6 +2,7 @@
 
 .button {
   display: inline-block;
+  margin: 0;
   padding: 0.5rem 2rem;
   font-family: var(--font-family);
   font-size: 0.75rem;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.3 (March 24, 2017)
+
+- Set `Button`'s `margin` property to `0`
+
 ## 0.4.3 (March 21, 2017)
 
 - Update `MultipleImages` to have a `rounded` flag to set a border-radius on itself

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Purpose
This PR removes the default margin added to `button` elements by setting `Button`'s `margin` property value to `0`.
### Things to Note
Nothing in particular to note here; a slight patch from what we had previously.
### Review
Curious to see how this change feels. 👍