### PR TITLE
Decrease font-size-small to 0.8rem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.6 (March 28, 2017)
+
+- Reduce `font-size-small` value from `0.9rem` to `0.8rem`
+
 ## 0.4.5 (March 24, 2017)
 
 - Add `newTabIcon` config to `Icon` 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {

--- a/variables-font.css
+++ b/variables-font.css
@@ -2,7 +2,7 @@
   --font-family: "Open Sans", sans-serif;
   --font-size: 1rem;
   --font-size-large: 2rem;
-  --font-size-small: 0.9rem;
+  --font-size-small: 0.8rem;
   --font-size-extra-small: 0.7rem;
   --font-weight-bold: 600;
   --font-weight: 400;


### PR DESCRIPTION
### Purpose
This PR decreases the `font-size-small` CSS variable value to `0.8rem` from `0.9rem`. This is to address a request from our "[Update card UI adjustments](https://trello.com/c/CXbVfDpi)" card on Trello.
### Things to Note
I checked this font size against our `font-size-extra-small` CSS variable, which is `0.7rem` and feels pretty good! 👍 
### Review
Changes made to `variables-font.css`. Curious to see how these feel!