### PR TITLE
Patch/linkifiedtext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.7 (April 6, 2017)
+
+- Remove `font-size` set on `Link`
+- Add `size` config to `LinkifiedText`
+
 ## 0.4.6 (March 28, 2017)
 
 - Reduce `font-size-small` value from `0.9rem` to `0.8rem`

--- a/Link/style.css
+++ b/Link/style.css
@@ -1,9 +1,5 @@
 @import '../variables.css';
 
-.link {
-  font-size: var(--font-size);
-}
-
 .link:link,
 .link:visited {
   color: var(--curious-blue);

--- a/LinkifiedText/index.jsx
+++ b/LinkifiedText/index.jsx
@@ -36,8 +36,8 @@ const calulateLinkifiedText = (links, curString, calculatedElements = []) => {
   );
 };
 
-const LinkifiedText = ({ children, links }) =>
-  <Text>{calulateLinkifiedText(links, children)}</Text>;
+const LinkifiedText = ({ children, links, size }) =>
+  <Text size={size}>{calulateLinkifiedText(links, children)}</Text>;
 
 LinkifiedText.propTypes = {
   children: PropTypes.string,
@@ -49,6 +49,7 @@ LinkifiedText.propTypes = {
       indices: PropTypes.arrayOf(React.PropTypes.number),
     }),
   ),
+  size: PropTypes.string,
 };
 
 LinkifiedText.defaultProps = {

--- a/LinkifiedText/story.jsx
+++ b/LinkifiedText/story.jsx
@@ -23,6 +23,19 @@ storiesOf('LinkifiedText')
   .add('no links', () => (
     <LinkifiedText>{'a b'}</LinkifiedText>
   ))
+  .add('size: small', () => (
+    <LinkifiedText
+      links={[{
+        rawString: 'http://t.co/0JG5Mcq',
+        displayString: 'blog.twitter.com/2011/05/twitte…',
+        url: 'http://blog.twitter.com/2011/05/twitter-for-mac-update.html',
+        indices: [2, 21],
+      }]}
+      size={'small'}
+    >
+      {'a http://t.co/0JG5Mcq b'}
+    </LinkifiedText>
+  ))
   .add('two links', () => (
     <LinkifiedText
       links={[

--- a/LinkifiedText/story.jsx
+++ b/LinkifiedText/story.jsx
@@ -17,6 +17,12 @@ storiesOf('LinkifiedText')
       {'a http://t.co/0JG5Mcq b'}
     </LinkifiedText>
   ))
+  .add('empty string', () => (
+    <LinkifiedText>{''}</LinkifiedText>
+  ))
+  .add('no links', () => (
+    <LinkifiedText>{'a b'}</LinkifiedText>
+  ))
   .add('two links', () => (
     <LinkifiedText
       links={[
@@ -36,10 +42,4 @@ storiesOf('LinkifiedText')
     >
       {'a http://t.co/0JG5Mcq b https://buffer.com c'}
     </LinkifiedText>
-  ))
-  .add('no links', () => (
-    <LinkifiedText>{'a b'}</LinkifiedText>
-  ))
-  .add('empty string', () => (
-    <LinkifiedText>{''}</LinkifiedText>
   ));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "babel-preset-es2015": "6.24.0",
     "babel-preset-react": "6.23.0",
     "babel-preset-stage-1": "6.22.0",
-    "css-loader": "0.27.3",
-    "eslint": "3.18.0",
+    "css-loader": "0.28.0",
+    "eslint": "3.19.0",
     "eslint-config-airbnb": "14.1.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "4.0.0",
@@ -64,7 +64,7 @@
     "react-test-renderer": "15.4.2",
     "storybook-addon-a11y": "0.0.4",
     "storyshots": "3.2.2",
-    "style-loader": "0.16.0"
+    "style-loader": "0.16.1"
   },
   "dependencies": {
     "uuid": "3.0.1"


### PR DESCRIPTION
### Purpose
This patch removes an explicit `font-size` CSS rule applied to the `Link` component so that we can set this as part of `LinkifiedText` as a prop.
### Things to Note
I've reorganized the files I've made changes to to have stories, declarations, etc. to be in alphabetical order. Hopefully, this might make navigating things a little smoother. 😄
### Review
Keen to see how this one feels. 👍
