### PR TITLE
Create IdTag component index/style/story

### DIFF
--- a/IdTag/index.jsx
+++ b/IdTag/index.jsx
@@ -1,0 +1,19 @@
+import React, { PropTypes } from 'react';
+import Text from '../Text';
+import styles from './style.css';
+
+const IdTag = ({
+  children,
+}) => {
+  return (
+    <span className={styles.label}>
+      <Text color={'white'}>{children}</Text>
+    </span>
+  );
+};
+
+IdTag.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default IdTag;

--- a/IdTag/story.jsx
+++ b/IdTag/story.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@kadira/storybook';
+import { checkA11y } from 'storybook-addon-a11y';
+import IdTag from './index';
+
+const children = 'GIF';
+
+storiesOf('IdTag')
+  .addDecorator(checkA11y)
+  .add('Default', () => (
+    <IdTag>{children}</IdTag>
+  ));

--- a/IdTag/style.css
+++ b/IdTag/style.css
@@ -1,0 +1,11 @@
+@import '../variables.css';
+
+.label {
+    position: absolute;
+    padding: 0.1rem 0.4rem 0.1rem 0.4rem;
+    background-color: var(--black);
+    border-radius: var(--border-radius);
+    opacity: .65;
+    letter-spacing: 0.1rem;
+    z-index: 2;
+}

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -2414,6 +2414,20 @@ exports[`Snapshots Icon warningIcon 1`] = `
 </span>
 `;
 
+exports[`Snapshots IdTag Default 1`] = `
+<span>
+  <span
+    className="label"
+  >
+    <span
+      className="text white"
+    >
+      GIF
+    </span>
+  </span>
+</span>
+`;
+
 exports[`Snapshots Image Default 1`] = `
 <span>
   <img

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ export Button from './Button';
 export Card from './Card';
 export Icon from './Icon';
 export * from './Icon/Icons';
+export IdTag from './IdTag';
 export Image from './Image';
 export Link from './Link';
 export LinkifiedText from './LinkifiedText';


### PR DESCRIPTION
### Purpose
Related trello card: https://trello.com/c/bPo7dEGU/131-create-tag-component-to-identify-differentiate-between-video-image-posts

Create an IdTag to add over the ImagePost thumbnail to differentiate between gif/video/image.

<img width="78" alt="screen shot 2017-04-10 at 3 10 56 pm" src="https://cloud.githubusercontent.com/assets/6446462/24865710/f3c08466-1dff-11e7-9531-ff4570a37360.png">

### Things to Note
TODO: Add change in changelog after merge when updating version.
TODO: Add test coverage for failing coverage check on this component.
### Review

**Some aspects to consider during review:**
* Functionality and implementation
* Architecture and performance
* Code readability and style

_A friendly reminder to add a reviewer/reviewers, add an assignee (yourself if you've worked on the change), set the code review status, and set the component request. :smile:_
