### PR TITLE
Add/unstyled new tab config to linkified text

### DIFF
--- a/LinkifiedText/index.jsx
+++ b/LinkifiedText/index.jsx
@@ -7,7 +7,6 @@ const linkDataToElement = (options, link, key) =>
   <Link href={link.url} key={key} unstyled={options.unstyled} newTab={options.newTab}>{link.displayString}</Link>;
 
 const calulateLinkifiedText = (options, links, curString, calculatedElements = []) => {
-  options = options || {};
   // nothing left to calculate, return all the caluculated pairs
   if (curString.length === 0) {
     calculatedElements.reverse();

--- a/LinkifiedText/index.jsx
+++ b/LinkifiedText/index.jsx
@@ -3,10 +3,11 @@ import Text from '../Text';
 import Link from '../Link';
 
 
-const linkDataToElement = (link, key) =>
-  <Link href={link.url} key={key}>{link.displayString}</Link>;
+const linkDataToElement = (options, link, key) =>
+  <Link href={link.url} key={key} unstyled={options.unstyled} newTab={options.newTab}>{link.displayString}</Link>;
 
-const calulateLinkifiedText = (links, curString, calculatedElements = []) => {
+const calulateLinkifiedText = (options, links, curString, calculatedElements = []) => {
+  options = options || {};
   // nothing left to calculate, return all the caluculated pairs
   if (curString.length === 0) {
     calculatedElements.reverse();
@@ -15,29 +16,39 @@ const calulateLinkifiedText = (links, curString, calculatedElements = []) => {
   // consume whats left of the string
   if (links.length === 0) {
     calculatedElements.push(curString);
-    return calulateLinkifiedText(links, '', calculatedElements);
+    return calulateLinkifiedText(options, links, '', calculatedElements);
   }
   const lastLink = links[links.length - 1];
   // text at the end that's not a link
   if (curString.length !== lastLink.indices[1]) {
     calculatedElements.push(curString.substring(lastLink.indices[1]));
     return calulateLinkifiedText(
+      options,
       links,
       curString.substring(0, lastLink.indices[1]),
       calculatedElements,
     );
   }
   // found a link!
-  calculatedElements.push(linkDataToElement(lastLink, calculatedElements.length));
+  calculatedElements.push(linkDataToElement(options, lastLink, calculatedElements.length));
   return calulateLinkifiedText(
+    options,
     links.slice(0, -1),
     curString.substring(0, lastLink.indices[0]),
     calculatedElements,
   );
 };
 
-const LinkifiedText = ({ children, links, size }) =>
-  <Text size={size}>{calulateLinkifiedText(links, children)}</Text>;
+const LinkifiedText = ({
+  children,
+  links,
+  newTab,
+  size,
+  unstyled,
+}) => {
+  const options = { unstyled, newTab };
+  return <Text size={size}>{calulateLinkifiedText(options, links, children)}</Text>;
+};
 
 LinkifiedText.propTypes = {
   children: PropTypes.string,
@@ -49,7 +60,9 @@ LinkifiedText.propTypes = {
       indices: PropTypes.arrayOf(React.PropTypes.number),
     }),
   ),
+  newTab: PropTypes.bool,
   size: PropTypes.string,
+  unstyled: PropTypes.bool,
 };
 
 LinkifiedText.defaultProps = {

--- a/LinkifiedText/story.jsx
+++ b/LinkifiedText/story.jsx
@@ -55,4 +55,30 @@ storiesOf('LinkifiedText')
     >
       {'a http://t.co/0JG5Mcq b https://buffer.com c'}
     </LinkifiedText>
+  ))
+  .add('unstyled', () => (
+    <LinkifiedText
+      links={[{
+        rawString: 'http://t.co/0JG5Mcq',
+        displayString: 'blog.twitter.com/2011/05/twitte…',
+        url: 'http://blog.twitter.com/2011/05/twitter-for-mac-update.html',
+        indices: [2, 21],
+      }]}
+      unstyled
+    >
+      {'a http://t.co/0JG5Mcq b'}
+    </LinkifiedText>
+  ))
+  .add('newTab', () => (
+    <LinkifiedText
+      links={[{
+        rawString: 'http://t.co/0JG5Mcq',
+        displayString: 'blog.twitter.com/2011/05/twitte…',
+        url: 'http://blog.twitter.com/2011/05/twitter-for-mac-update.html',
+        indices: [2, 21],
+      }]}
+      newTab
+    >
+      {'a http://t.co/0JG5Mcq b'}
+    </LinkifiedText>
   ));

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -6018,6 +6018,24 @@ exports[`Snapshots LinkifiedText empty string 1`] = `
 </span>
 `;
 
+exports[`Snapshots LinkifiedText newTab 1`] = `
+<span>
+  <span
+    className="text"
+  >
+    a 
+    <a
+      className="link"
+      href="http://blog.twitter.com/2011/05/twitter-for-mac-update.html"
+      target="_blank"
+    >
+      blog.twitter.com/2011/05/twitte…
+    </a>
+     b
+  </span>
+</span>
+`;
+
 exports[`Snapshots LinkifiedText no links 1`] = `
 <span>
   <span
@@ -6068,6 +6086,24 @@ exports[`Snapshots LinkifiedText two links 1`] = `
       buffer.com
     </a>
      c
+  </span>
+</span>
+`;
+
+exports[`Snapshots LinkifiedText unstyled 1`] = `
+<span>
+  <span
+    className="text"
+  >
+    a 
+    <a
+      className="link unstyled"
+      href="http://blog.twitter.com/2011/05/twitter-for-mac-update.html"
+      target="_self"
+    >
+      blog.twitter.com/2011/05/twitte…
+    </a>
+     b
   </span>
 </span>
 `;


### PR DESCRIPTION
### Purpose
Related trello card: https://trello.com/c/ctVhLxmB/111-link-component-add-target-config-add-unstyled-config
- Add 'unstyled' config to LinkifiedText component - which then uses Link component's 'unstyled' config
- Add 'newTab' config to LinkifiedText component - which then uses Link components's 'newTab' config 

### Things to Note
Update changelog and version once merged.
### Review

**Some aspects to consider during review:**
* Functionality and implementation
* Architecture and performance
* Code readability and style

_A friendly reminder to add a reviewer/reviewers, add an assignee (yourself if you've worked on the change), set the code review status, and set the component request. :smile:_
