### PR TITLE
Add/migrate to prop types packaage

### DIFF
--- a/Button/index.jsx
+++ b/Button/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { classNames } from '../lib/utils';
 import styles from './style.css';
 

--- a/Card/index.jsx
+++ b/Card/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { classNames } from '../lib/utils';
 import styles from './style.css';
 

--- a/Icon/index.jsx
+++ b/Icon/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { classNames } from '../lib/utils';
 import styles from './style.css';
 

--- a/IdTag/index.jsx
+++ b/IdTag/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Text from '../Text';
 import styles from './style.css';
 

--- a/Image/index.jsx
+++ b/Image/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { classNames } from '../lib/utils';
 import styles from './style.css';
 

--- a/Input/index.jsx
+++ b/Input/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { classNames } from '../lib/utils';
 import styles from './style.css';
 import Text from '../Text';

--- a/InputDate/index.jsx
+++ b/InputDate/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import DayPicker from 'react-day-picker';
 import styles from './style.css';
 import Text from '../Text';

--- a/Link/index.jsx
+++ b/Link/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { classNames } from '../lib/utils';
 import styles from './style.css';
 

--- a/LinkifiedText/index.jsx
+++ b/LinkifiedText/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Text from '../Text';
 import Link from '../Link';
 
@@ -46,7 +47,7 @@ LinkifiedText.propTypes = {
       rawString: PropTypes.string,
       displayString: PropTypes.string,
       expandedUrl: PropTypes.string,
-      indices: PropTypes.arrayOf(React.PropTypes.number),
+      indices: PropTypes.arrayOf(PropTypes.number),
     }),
   ),
   size: PropTypes.string,

--- a/List/index.jsx
+++ b/List/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import uuid from 'uuid';
 import ListItem from '../ListItem';
 import style from './style.css';

--- a/ListItem/index.jsx
+++ b/ListItem/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import style from './style.css';
 
 const ListItem = ({ children }) =>

--- a/Loader/index.jsx
+++ b/Loader/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { BufferTopIcon, BufferMiddleIcon, BufferBottomIcon } from '../Icon/Icons';
 import Text from '../Text';
 import styles from './style.css';

--- a/MultipleImages/index.jsx
+++ b/MultipleImages/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import uuid from 'uuid';
 import { classNames } from '../lib/utils';
 import Image from '../Image';

--- a/NavBar/index.jsx
+++ b/NavBar/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import BufferIcon from '../Icon/Icons/BufferIcon';
 import Text from '../Text';
 import styles from './style.css';

--- a/Overlay/index.jsx
+++ b/Overlay/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './style.css';
 
 const Overlay = ({ onClick, transparent }) =>

--- a/Popover/index.jsx
+++ b/Popover/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './style.css';
 import Overlay from '../Overlay';
 

--- a/Text/index.jsx
+++ b/Text/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { classNames } from '../lib/utils';
 import styles from './style.css';
 

--- a/Video/index.jsx
+++ b/Video/index.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { classNames } from '../lib/utils';
 import styles from './style.css';
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "prop-types": "15.5.8",
-    "react-day-picker": "5.2.1",
+    "react-day-picker": "5.2.3",
     "uuid": "3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "style-loader": "0.16.1"
   },
   "dependencies": {
+    "prop-types": "15.5.8",
     "react-day-picker": "5.2.1",
     "uuid": "3.0.1"
   }


### PR DESCRIPTION
### Purpose
Related trello card: https://trello.com/c/a5fmJoFQ/134-migrate-to-new-stand-alone-proptypes-package
- Add 'prop-types' to dependencies
- Do not import 'PropTypes' from main react package
- import 'PropTypes' from stand-alone npm package
- Update each component to use new 'PropTypes' package
### Things to Note

### Review

**Some aspects to consider during review:**
* Functionality and implementation
* Architecture and performance
* Code readability and style

_A friendly reminder to add a reviewer/reviewers, add an assignee (yourself if you've worked on the change), set the code review status, and set the component request. :smile:_
