### PR TITLE
Add/background color config to card component

### DIFF
--- a/Card/index.jsx
+++ b/Card/index.jsx
@@ -5,6 +5,7 @@ import styles from './style.css';
 
 const Card = ({
   children,
+  color,
   doublePadding,
   empty,
   faded,
@@ -23,6 +24,7 @@ const Card = ({
     hovered,
     'no-border': noBorder,
     'no-padding': noPadding,
+    offWhite: color === 'off-white',
   });
   return (
     <div
@@ -37,6 +39,7 @@ const Card = ({
 
 Card.propTypes = {
   children: PropTypes.node,
+  color: PropTypes.oneOf(['off-white']),
   doublePadding: PropTypes.bool,
   empty: PropTypes.bool,
   faded: PropTypes.bool,

--- a/Card/index.jsx
+++ b/Card/index.jsx
@@ -15,6 +15,7 @@ const Card = ({
   noPadding,
   onMouseEnter,
   onMouseLeave,
+  reducedPadding,
 }) => {
   const classes = classNames(styles, 'card', {
     'double-padding': doublePadding,
@@ -22,6 +23,7 @@ const Card = ({
     faded,
     failed,
     hovered,
+    'reduced-padding': reducedPadding,
     'no-border': noBorder,
     'no-padding': noPadding,
     offWhite: color === 'off-white',
@@ -49,6 +51,7 @@ Card.propTypes = {
   noPadding: PropTypes.bool,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
+  reducedPadding: PropTypes.bool,
 };
 
 export default Card;

--- a/Card/story.jsx
+++ b/Card/story.jsx
@@ -43,4 +43,7 @@ storiesOf('Card')
     >
       What is a Product Designer? An awesome story by <Link href={'#'}>@jgadapee</Link> over on Medium! <Link href={'#'}>http://buff.ly/1LTbUqv</Link>
     </Card>
+  ))
+  .add('off-white background color', () => (
+    <Card color={'off-white'}>What is a Product Designer? An awesome story by <Link href={'#'}>@jgadapee</Link> over on Medium! <Link href={'#'}>http://buff.ly/1LTbUqv</Link></Card>
   ));

--- a/Card/story.jsx
+++ b/Card/story.jsx
@@ -46,4 +46,7 @@ storiesOf('Card')
   ))
   .add('off-white background color', () => (
     <Card color={'off-white'}>What is a Product Designer? An awesome story by <Link href={'#'}>@jgadapee</Link> over on Medium! <Link href={'#'}>http://buff.ly/1LTbUqv</Link></Card>
+  ))
+  .add('reducedPadding', () => (
+    <Card reducedPadding>What is a Product Designer? An awesome story by <Link href={'#'}>@jgadapee</Link> over on Medium! <Link href={'#'}>http://buff.ly/1LTbUqv</Link></Card>
   ));

--- a/Card/style.css
+++ b/Card/style.css
@@ -36,6 +36,10 @@
   border-color: var(--torch-red);
 }
 
+.reduced-padding {
+  padding: 1rem;
+}
+
 .no-border {
   border: 0;
 }

--- a/Card/style.css
+++ b/Card/style.css
@@ -43,3 +43,7 @@
 .no-padding {
   padding: 0;
 }
+
+.offWhite {
+  background-color: var(--off-white);
+}

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -459,12 +459,66 @@ exports[`Snapshots Card noPadding 1`] = `
 </span>
 `;
 
+exports[`Snapshots Card off-white background color 1`] = `
+<span>
+  <div
+    className="card offWhite"
+    onMouseEnter={undefined}
+    onMouseLeave={undefined}
+  >
+    What is a Product Designer? An awesome story by 
+    <a
+      className="link"
+      href="#"
+      target="_self"
+    >
+      @jgadapee
+    </a>
+     over on Medium! 
+    <a
+      className="link"
+      href="#"
+      target="_self"
+    >
+      http://buff.ly/1LTbUqv
+    </a>
+  </div>
+</span>
+`;
+
 exports[`Snapshots Card onMouseEnter + onMouseLeave 1`] = `
 <span>
   <div
     className="card"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+  >
+    What is a Product Designer? An awesome story by 
+    <a
+      className="link"
+      href="#"
+      target="_self"
+    >
+      @jgadapee
+    </a>
+     over on Medium! 
+    <a
+      className="link"
+      href="#"
+      target="_self"
+    >
+      http://buff.ly/1LTbUqv
+    </a>
+  </div>
+</span>
+`;
+
+exports[`Snapshots Card reducedPadding 1`] = `
+<span>
+  <div
+    className="card reduced-padding"
+    onMouseEnter={undefined}
+    onMouseLeave={undefined}
   >
     What is a Product Designer? An awesome story by 
     <a

--- a/variables-colors.css
+++ b/variables-colors.css
@@ -24,6 +24,7 @@
 
   --black: #000;
   --white: #fff;
+  --off-white: #fcfcfc;
 
   --shamrock: #2fd566;
   --saffron: #f1cb3a;


### PR DESCRIPTION
### Purpose
Related trello cards: 
https://trello.com/c/PAcqXGHe/139-reduce-padding-in-retweet-section-of-card
https://trello.com/c/vtMLBxRL/140-add-background-color-fcfcfc-to-retweet-card

- Add 'color' config to Card component to allow 'off-white' color to be set as background-color
- Add 'reducedPadding' config to Card component to use padding of 1rem instead of 1.5

### Things to Note

### Review

**Some aspects to consider during review:**
* Functionality and implementation
* Architecture and performance
* Code readability and style

_A friendly reminder to add a reviewer/reviewers, add an assignee (yourself if you've worked on the change), set the code review status, and set the component request. :smile:_
