### PR TITLE
Patch/sectionheader flex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.22 (May 17, 2017)
+
+- Update `SectionHeader` component CSS `flex-direction` property add `align-items` property with `center` value
+
 ## 0.4.21 (May 17, 2017)
 
 - Add `SectionHeader` component

--- a/SectionHeader/story.jsx
+++ b/SectionHeader/story.jsx
@@ -10,4 +10,9 @@ storiesOf('SectionHeader')
   .addDecorator(checkA11y)
   .add('default', () => (
     <SectionHeader />
+  ))
+  .add('with content', () => (
+    <SectionHeader>
+      A section title
+    </SectionHeader>
   ));

--- a/SectionHeader/style.css
+++ b/SectionHeader/style.css
@@ -2,7 +2,8 @@
 
 .sectionHeader {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
   height: 3rem;
   border-bottom: var(--border-width) solid var(--mystic);
 }

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -10625,6 +10625,16 @@ exports[`Snapshots SectionHeader default 1`] = `
 </span>
 `;
 
+exports[`Snapshots SectionHeader with content 1`] = `
+<span>
+  <div
+    className="sectionHeader"
+  >
+    A section title
+  </div>
+</span>
+`;
+
 exports[`Snapshots Text Black 1`] = `
 <span>
   <span

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Purpose
This PR updates our `SectionHeader`'s `flex-direction` CSS property value from `column` to `row` and adds an `align-items` property with a `center` value.
### Review
Keen to see how this one feels. 👍 