### PR TITLE
Replace backgroundColor with background for icon config

### DIFF
--- a/ButtonStateless/index.jsx
+++ b/ButtonStateless/index.jsx
@@ -84,7 +84,7 @@ const Button = ({
       lineHeight: 0,
     },
     iconHovered: {
-      backgroundColor: transparent,
+      background: transparent,
       border: 0,
     },
     large: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.6 (May 24, 2017)
+
+- Replace `backgroundColor` with `background` on `icon` config hover state
+
 ## 0.5.5 (May 24, 2017)
 
 - Add `iconHovered` state to `ButtonStateless` `icon` config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Purpose
This PR replaces `backgroundColor` with `background` on `iconHovered` object.
### Things to Note
It's super curious why this doesn't show up on buffer-components but on buffer-web-components. 🤔
### Review
Curious to see how this feels. 👍