### PR TITLE
Patch/inputtime display fix

### DIFF
--- a/InputTime/index.jsx
+++ b/InputTime/index.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { calculateStyles } from '../lib/utils';
 
 // generate array of numbers (inclusive)
 const genArray = (start, end) => [...Array(end + 1).keys()].slice(start);
@@ -7,7 +8,7 @@ const leftPadTimeUnit = timeUnit => (timeUnit < 10 ? `0${timeUnit}` : timeUnit);
 /* eslint-disable react/prop-types */
 
 const renderAmPm = ({ value, onChange, submitting }) =>
-  <select
+  (<select
     value={value.hours < 12 ? 'am' : 'pm'}
     disabled={submitting}
     onChange={e => onChange({
@@ -19,7 +20,7 @@ const renderAmPm = ({ value, onChange, submitting }) =>
   >
     <option value="am">am</option>
     <option value="pm">pm</option>
-  </select>;
+  </select>);
 
 /* eslint-enable react/prop-types */
 
@@ -47,11 +48,16 @@ const InputTime = ({
     submitting,
   },
 }) => {
+  const style = calculateStyles({
+    default: {
+      display: 'inline-flex',
+    },
+  });
   if (!value) {
     value = { hours: 0, minutes: 0 };
   }
   return (
-    <div>
+    <div style={style}>
       <select
         style={marginRight}
         disabled={submitting}
@@ -62,12 +68,12 @@ const InputTime = ({
           select24Hours || value.hours < 12 ? 0 : 12,
           select24Hours || value.hours > 11 ? 23 : 11,
         ).map(hour =>
-          <option
+          (<option
             key={hour}
             value={hour}
           >
             {leftPadTimeUnit(displayHour(hour, select24Hours))}
-          </option>)
+          </option>))
         }
       </select>
       <select

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -9380,7 +9380,13 @@ exports[`Snapshots InputPassword with submitting = true 1`] = `
 
 exports[`Snapshots InputTime default 1`] = `
 <span>
-  <div>
+  <div
+    style={
+      Object {
+        "display": "inline-flex",
+      }
+    }
+  >
     <select
       disabled={undefined}
       onChange={[Function]}
@@ -9785,7 +9791,13 @@ exports[`Snapshots InputTime default 1`] = `
 
 exports[`Snapshots InputTime with 24 hour selection 1`] = `
 <span>
-  <div>
+  <div
+    style={
+      Object {
+        "display": "inline-flex",
+      }
+    }
+  >
     <select
       disabled={undefined}
       onChange={[Function]}
@@ -10230,7 +10242,13 @@ exports[`Snapshots InputTime with 24 hour selection 1`] = `
 
 exports[`Snapshots InputTime with afternoon value set 1`] = `
 <span>
-  <div>
+  <div
+    style={
+      Object {
+        "display": "inline-flex",
+      }
+    }
+  >
     <select
       disabled={undefined}
       onChange={[Function]}
@@ -10635,7 +10653,13 @@ exports[`Snapshots InputTime with afternoon value set 1`] = `
 
 exports[`Snapshots InputTime with afternoon value set and 24 hour selection 1`] = `
 <span>
-  <div>
+  <div
+    style={
+      Object {
+        "display": "inline-flex",
+      }
+    }
+  >
     <select
       disabled={undefined}
       onChange={[Function]}
@@ -11080,7 +11104,13 @@ exports[`Snapshots InputTime with afternoon value set and 24 hour selection 1`] 
 
 exports[`Snapshots InputTime with form submitting 1`] = `
 <span>
-  <div>
+  <div
+    style={
+      Object {
+        "display": "inline-flex",
+      }
+    }
+  >
     <select
       disabled={true}
       onChange={[Function]}
@@ -11485,7 +11515,13 @@ exports[`Snapshots InputTime with form submitting 1`] = `
 
 exports[`Snapshots InputTime with value set 1`] = `
 <span>
-  <div>
+  <div
+    style={
+      Object {
+        "display": "inline-flex",
+      }
+    }
+  >
     <select
       disabled={undefined}
       onChange={[Function]}


### PR DESCRIPTION
### Purpose
This PR fixes a slight browser behavior we have when rendering a `select` element within a `div`.

Without this fix:
<img width="176" alt="screen shot 2017-05-25 at 9 41 53 pm" src="https://cloud.githubusercontent.com/assets/1685602/26469986/e3d176de-4193-11e7-93dd-3ac0abfb078e.png">

With this fix:
<img width="187" alt="screen shot 2017-05-25 at 9 41 43 pm" src="https://cloud.githubusercontent.com/assets/1685602/26469989/ebbfb1d0-4193-11e7-987e-aaecc0948a7e.png">

### Things to Note
This fix doesn't change any functionality and is purely a style tweak. 😄
### Review
Would love to see how this feels!