### PR TITLE
Add/off white color to button stateless component

### DIFF
--- a/ButtonStateless/index.jsx
+++ b/ButtonStateless/index.jsx
@@ -11,6 +11,7 @@ import {
   white,
   curiousBlue,
   geyser,
+  offWhite,
   outerSpace,
   transparent,
   torchRed,
@@ -40,6 +41,7 @@ const Button = ({
   secondary,
   small,
   tertiary,
+  quaternary,
   warning,
   noStyle,
 }) => {
@@ -102,6 +104,15 @@ const Button = ({
       color: outerSpace,
       backgroundColor: transparent,
     },
+    quaternary: {
+      color: outerSpace,
+      backgroundColor: offWhite,
+      borderColor: geyser,
+    },
+    quaternaryHovered: {
+      color: outerSpace,
+      backgroundColor: offWhite,
+    },
     warning: {
       color: outerSpace,
       backgroundColor: transparent,
@@ -143,6 +154,8 @@ const Button = ({
     small,
     tertiary,
     tertiaryHovered: tertiary && hovered && !disabled,
+    quaternary,
+    quaternaryHovered: quaternary && hovered && !disabled,
     warning,
     warningHovered: warning && hovered && !disabled,
     fillContainer,
@@ -181,6 +194,7 @@ Button.propTypes = {
   secondary: PropTypes.bool,
   small: PropTypes.bool,
   tertiary: PropTypes.bool,
+  quaternary: PropTypes.bool,
   warning: PropTypes.bool,
 };
 

--- a/ButtonStateless/story.jsx
+++ b/ButtonStateless/story.jsx
@@ -29,6 +29,8 @@ storiesOf('ButtonStateless')
       <Button disabled small>Button text</Button><br /><br />
       <p>Tertiary</p>
       <Button disabled tertiary>Button text</Button><br /><br />
+      <p>Quaternary</p>
+      <Button disabled quaternary>Button text</Button><br /><br />
       <p>Warning</p>
       <Button disabled warning>Button text</Button>
       <p>Click Events Should Not Fire</p>

--- a/ButtonStateless/story.jsx
+++ b/ButtonStateless/story.jsx
@@ -62,6 +62,8 @@ storiesOf('ButtonStateless')
       <Button hovered small>Button text</Button><br /><br />
       <p>Tertiary</p>
       <Button hovered tertiary>Button text</Button><br /><br />
+      <p>Quaternary</p>
+      <Button hovered quaternary>Button text</Button><br /><br />
       <p>Warning</p>
       <Button hovered warning>Button text</Button>
       <p>Disabled</p>
@@ -92,6 +94,9 @@ storiesOf('ButtonStateless')
   ))
   .add('tertiary', () => (
     <Button tertiary>Button text</Button>
+  ))
+  .add('quaternary', () => (
+    <Button quaternary>Button text</Button>
   ))
   .add('warning', () => (
     <Button warning>Button text</Button>

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -446,6 +446,40 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
     <br />
     <br />
     <p>
+      Quaternary
+    </p>
+    <button
+      disabled={true}
+      onBlur={undefined}
+      onClick={undefined}
+      onFocus={undefined}
+      onMouseEnter={undefined}
+      onMouseLeave={undefined}
+      style={
+        Object {
+          "backgroundColor": "#fcfcfc",
+          "border": "0.063rem solid transparent",
+          "borderColor": "#ced7df",
+          "borderRadius": "2rem",
+          "color": "#323b43",
+          "cursor": "pointer",
+          "display": "inline-block",
+          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontSize": "0.8rem",
+          "fontWeight": 400,
+          "margin": "0",
+          "opacity": 0.3,
+          "outline": "none",
+          "padding": "0.5rem 2rem",
+          "transition": "background-color 0.1s linear",
+        }
+      }
+    >
+      Button text
+    </button>
+    <br />
+    <br />
+    <p>
       Warning
     </p>
     <button

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -833,6 +833,40 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
     <br />
     <br />
     <p>
+      Quaternary
+    </p>
+    <button
+      disabled={undefined}
+      onBlur={undefined}
+      onClick={undefined}
+      onFocus={undefined}
+      onMouseEnter={undefined}
+      onMouseLeave={undefined}
+      style={
+        Object {
+          "backgroundColor": "#fcfcfc",
+          "border": "0.063rem solid transparent",
+          "borderColor": "#ced7df",
+          "borderRadius": "2rem",
+          "color": "#323b43",
+          "cursor": "pointer",
+          "display": "inline-block",
+          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontSize": "0.8rem",
+          "fontWeight": 400,
+          "margin": "0",
+          "outline": "none",
+          "padding": "0.5rem 2rem",
+          "textDecoration": "none",
+          "transition": "background-color 0.1s linear",
+        }
+      }
+    >
+      Button text
+    </button>
+    <br />
+    <br />
+    <p>
       Warning
     </p>
     <button
@@ -1109,6 +1143,39 @@ exports[`Snapshots ButtonStateless onMouseEnter + onMouseLeave 1`] = `
     }
   >
     Mouse Enter + Mouse Leave
+  </button>
+</span>
+`;
+
+exports[`Snapshots ButtonStateless quaternary 1`] = `
+<span>
+  <button
+    disabled={undefined}
+    onBlur={undefined}
+    onClick={undefined}
+    onFocus={undefined}
+    onMouseEnter={undefined}
+    onMouseLeave={undefined}
+    style={
+      Object {
+        "backgroundColor": "#fcfcfc",
+        "border": "0.063rem solid transparent",
+        "borderColor": "#ced7df",
+        "borderRadius": "2rem",
+        "color": "#323b43",
+        "cursor": "pointer",
+        "display": "inline-block",
+        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontSize": "0.8rem",
+        "fontWeight": 400,
+        "margin": "0",
+        "outline": "none",
+        "padding": "0.5rem 2rem",
+        "transition": "background-color 0.1s linear",
+      }
+    }
+  >
+    Button text
   </button>
 </span>
 `;


### PR DESCRIPTION
### Purpose
Adds `quaternary` to `ButtonStateless` component.
* similar to `tertiary` but background color is `offWhite`
* for use in new collabTool Empty view email notification banner design
### Things to Note
Chose to create a new button type since the aim of components is to keep things consistent accross the app. I'm making the assumption that it will be used as we increase component use in buffer-web. 

I thought adding a 'color' config might introduce too much variation. 

Happy to chat more or change this if it doesn't feel good. 
### Review

**Some aspects to consider during review:**
* Functionality and implementation
* Architecture and performance
* Code readability and style

_A friendly reminder to add a reviewer/reviewers, add an assignee (yourself if you've worked on the change), set the code review status, and set the component request. :smile:_
