### PR TITLE
Use preferred browser prefix key names in InputTime

### DIFF
--- a/InputTime/index.jsx
+++ b/InputTime/index.jsx
@@ -24,8 +24,8 @@ const renderAmPm = ({
       background: 'transparent',
       margin: 0,
       padding: 0,
-      '-webkit-appearance': 'none',
-      '-moz-appearance': 'none',
+      WebkitAppearance: 'none',
+      MozAppearance: 'none',
     },
   }, {
     noStyle,

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -10851,8 +10851,8 @@ exports[`Snapshots InputTime noStyle 1`] = `
       onChange={[Function]}
       style={
         Object {
-          "-moz-appearance": "none",
-          "-webkit-appearance": "none",
+          "MozAppearance": "none",
+          "WebkitAppearance": "none",
           "background": "transparent",
           "border": 0,
           "display": "inline-flex",


### PR DESCRIPTION
### Purpose
This PR removes the browser prefix strings as keys and replaces them with preferred keys.
### Things to Note
This feels like a super small, non-breaking change. 👍 
### Review
Keen to see how this one feels! 👍 