### PR TITLE
Patch/inputtime and font adjustments

### DIFF
--- a/InputTime/index.jsx
+++ b/InputTime/index.jsx
@@ -16,7 +16,6 @@ const renderAmPm = ({
 }) => {
   const style = calculateStyles({
     default: {
-      display: 'inline-flex',
       marginRight: '0.25rem',
     },
     noStyle: {

--- a/InputTime/index.jsx
+++ b/InputTime/index.jsx
@@ -107,12 +107,12 @@ const InputTime = ({
           select24Hours || value.hours < 12 ? 0 : 12,
           select24Hours || value.hours > 11 ? 23 : 11,
         ).map(hour =>
-          (<option
+          <option
             key={hour}
             value={hour}
           >
             {leftPadTimeUnit(displayHour(hour, select24Hours))}
-          </option>))
+          </option>)
         }
       </select>
       <select

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -17,7 +17,7 @@ exports[`Snapshots Button default 1`] = `
         "color": "#fff",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -50,7 +50,7 @@ exports[`Snapshots Button warning button 1`] = `
         "color": "#323b43",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -197,7 +197,7 @@ exports[`Snapshots ButtonStateless Default 1`] = `
         "color": "#fff",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -229,7 +229,7 @@ exports[`Snapshots ButtonStateless borderless 1`] = `
         "color": "#168eea",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -265,7 +265,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -298,7 +298,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
           "color": "#168eea",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -331,7 +331,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "fontWeight": 400,
           "margin": "0",
@@ -365,7 +365,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
           "color": "#168eea",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -398,7 +398,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -432,7 +432,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
           "color": "#323b43",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -466,7 +466,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
           "color": "#323b43",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -500,7 +500,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
           "color": "#323b43",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -531,7 +531,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -578,7 +578,7 @@ exports[`Snapshots ButtonStateless disabled 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "0.8rem",
             "fontWeight": 400,
           }
@@ -615,7 +615,7 @@ exports[`Snapshots ButtonStateless fillContainer 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -651,7 +651,7 @@ exports[`Snapshots ButtonStateless focused 1`] = `
         "color": "#168eea",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -687,7 +687,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -720,7 +720,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
           "color": "#137ac9",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -753,7 +753,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "fontWeight": 400,
           "margin": "0",
@@ -787,7 +787,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
           "color": "#137ac9",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -820,7 +820,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -854,7 +854,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
           "color": "#323b43",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -888,7 +888,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
           "color": "#323b43",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -922,7 +922,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -953,7 +953,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
           "color": "#fff",
           "cursor": "pointer",
           "display": "inline-block",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
           "margin": "0",
@@ -1000,7 +1000,7 @@ exports[`Snapshots ButtonStateless hovered 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "0.8rem",
             "fontWeight": 400,
           }
@@ -1030,7 +1030,7 @@ exports[`Snapshots ButtonStateless large 1`] = `
         "color": "#fff",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
         "margin": "0",
@@ -1078,7 +1078,7 @@ exports[`Snapshots ButtonStateless noStyle 1`] = `
       style={
         Object {
           "color": "#59626a",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "0.8rem",
           "fontWeight": 400,
         }
@@ -1107,7 +1107,7 @@ exports[`Snapshots ButtonStateless onClick event 1`] = `
         "color": "#fff",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -1139,7 +1139,7 @@ exports[`Snapshots ButtonStateless onFocus + onBlur 1`] = `
         "color": "#fff",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -1171,7 +1171,7 @@ exports[`Snapshots ButtonStateless onMouseEnter + onMouseLeave 1`] = `
         "color": "#fff",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -1204,7 +1204,7 @@ exports[`Snapshots ButtonStateless quaternary 1`] = `
         "color": "#323b43",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -1237,7 +1237,7 @@ exports[`Snapshots ButtonStateless secondary 1`] = `
         "color": "#168eea",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -1269,7 +1269,7 @@ exports[`Snapshots ButtonStateless small 1`] = `
         "color": "#fff",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -1302,7 +1302,7 @@ exports[`Snapshots ButtonStateless tertiary 1`] = `
         "color": "#323b43",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -1335,7 +1335,7 @@ exports[`Snapshots ButtonStateless warning 1`] = `
         "color": "#323b43",
         "cursor": "pointer",
         "display": "inline-block",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
         "margin": "0",
@@ -4510,7 +4510,7 @@ exports[`Snapshots IdTag Default 1`] = `
       style={
         Object {
           "color": "#fff",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "fontWeight": 400,
         }
@@ -4819,7 +4819,7 @@ exports[`Snapshots Input default 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -4848,7 +4848,7 @@ exports[`Snapshots Input focused 1`] = `
           "borderColor": "#168eea",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -4876,7 +4876,7 @@ exports[`Snapshots Input onFocus + onBlur 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -4904,7 +4904,7 @@ exports[`Snapshots Input with error 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -4925,7 +4925,7 @@ exports[`Snapshots Input with error 1`] = `
           "borderColor": "#ff1e1e",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -4946,7 +4946,7 @@ exports[`Snapshots Input with error 1`] = `
         style={
           Object {
             "color": "#ff1e1e",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -4973,7 +4973,7 @@ exports[`Snapshots Input with label 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -4993,7 +4993,7 @@ exports[`Snapshots Input with label 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -5021,7 +5021,7 @@ exports[`Snapshots Input with placeholder 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -5041,7 +5041,7 @@ exports[`Snapshots Input with placeholder 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -5069,7 +5069,7 @@ exports[`Snapshots Input with submitting = true 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -5097,7 +5097,7 @@ exports[`Snapshots Input with type = email 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -5125,7 +5125,7 @@ exports[`Snapshots Input with type = password 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -8283,7 +8283,7 @@ exports[`Snapshots InputDate with error 1`] = `
         style={
           Object {
             "color": "#ff1e1e",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -9094,7 +9094,7 @@ exports[`Snapshots InputEmail default 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9123,7 +9123,7 @@ exports[`Snapshots InputEmail focused 1`] = `
           "borderColor": "#168eea",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9151,7 +9151,7 @@ exports[`Snapshots InputEmail onFocus + onBlur 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9179,7 +9179,7 @@ exports[`Snapshots InputEmail with error 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -9200,7 +9200,7 @@ exports[`Snapshots InputEmail with error 1`] = `
           "borderColor": "#ff1e1e",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9221,7 +9221,7 @@ exports[`Snapshots InputEmail with error 1`] = `
         style={
           Object {
             "color": "#ff1e1e",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -9248,7 +9248,7 @@ exports[`Snapshots InputEmail with label 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -9268,7 +9268,7 @@ exports[`Snapshots InputEmail with label 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9296,7 +9296,7 @@ exports[`Snapshots InputEmail with placeholder 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -9316,7 +9316,7 @@ exports[`Snapshots InputEmail with placeholder 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9344,7 +9344,7 @@ exports[`Snapshots InputEmail with submitting = true 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9372,7 +9372,7 @@ exports[`Snapshots InputPassword default 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9401,7 +9401,7 @@ exports[`Snapshots InputPassword focused 1`] = `
           "borderColor": "#168eea",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9429,7 +9429,7 @@ exports[`Snapshots InputPassword onFocus + onBlur 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9457,7 +9457,7 @@ exports[`Snapshots InputPassword with error 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -9478,7 +9478,7 @@ exports[`Snapshots InputPassword with error 1`] = `
           "borderColor": "#ff1e1e",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9499,7 +9499,7 @@ exports[`Snapshots InputPassword with error 1`] = `
         style={
           Object {
             "color": "#ff1e1e",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -9526,7 +9526,7 @@ exports[`Snapshots InputPassword with label 1`] = `
         style={
           Object {
             "color": "#59626a",
-            "fontFamily": "\\"Open Sans\\" sans-serif",
+            "fontFamily": "\\"Open Sans\\", sans-serif",
             "fontSize": "1rem",
             "fontWeight": 400,
           }
@@ -9546,7 +9546,7 @@ exports[`Snapshots InputPassword with label 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -9574,7 +9574,7 @@ exports[`Snapshots InputPassword with submitting = true 1`] = `
           "border": "0.063rem solid #ced7df",
           "borderRadius": "0.126rem",
           "boxSizing": "border-box",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "outline": 0,
           "padding": "0.5rem",
@@ -13810,7 +13810,7 @@ exports[`Snapshots LinkifiedText default 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -13843,7 +13843,7 @@ exports[`Snapshots LinkifiedText empty string 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -13858,7 +13858,7 @@ exports[`Snapshots LinkifiedText newTab 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -13891,7 +13891,7 @@ exports[`Snapshots LinkifiedText no links 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -13908,7 +13908,7 @@ exports[`Snapshots LinkifiedText size: small 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
       }
@@ -13941,7 +13941,7 @@ exports[`Snapshots LinkifiedText two links 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -13990,7 +13990,7 @@ exports[`Snapshots LinkifiedText unstyled 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -14237,7 +14237,7 @@ exports[`Snapshots Loader withText 1`] = `
       style={
         Object {
           "color": "#59626a",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "fontWeight": 400,
         }
@@ -14885,7 +14885,7 @@ exports[`Snapshots NavBar Default 1`] = `
       style={
         Object {
           "color": "#59626a",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "fontWeight": 600,
         }
@@ -14897,7 +14897,7 @@ exports[`Snapshots NavBar Default 1`] = `
       style={
         Object {
           "color": "#59626a",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "fontWeight": 400,
         }
@@ -14962,7 +14962,7 @@ exports[`Snapshots NavBar Subtitle 1`] = `
       style={
         Object {
           "color": "#59626a",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "fontWeight": 600,
         }
@@ -14974,7 +14974,7 @@ exports[`Snapshots NavBar Subtitle 1`] = `
       style={
         Object {
           "color": "#59626a",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "fontWeight": 400,
         }
@@ -15623,7 +15623,7 @@ exports[`Snapshots Text black 1`] = `
     style={
       Object {
         "color": "#000",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -15640,7 +15640,7 @@ exports[`Snapshots Text bold 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 600,
       }
@@ -15657,7 +15657,7 @@ exports[`Snapshots Text curiousBlue 1`] = `
     style={
       Object {
         "color": "#168eea",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -15674,7 +15674,7 @@ exports[`Snapshots Text default 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -15691,7 +15691,7 @@ exports[`Snapshots Text extra small 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.7rem",
         "fontWeight": 400,
       }
@@ -15708,7 +15708,7 @@ exports[`Snapshots Text large 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "2rem",
         "fontWeight": 400,
       }
@@ -15725,7 +15725,7 @@ exports[`Snapshots Text mini 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.9rem",
         "fontWeight": 400,
       }
@@ -15742,7 +15742,7 @@ exports[`Snapshots Text outerSpace 1`] = `
     style={
       Object {
         "color": "#323b43",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -15759,7 +15759,7 @@ exports[`Snapshots Text shuttleGray 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -15776,7 +15776,7 @@ exports[`Snapshots Text small 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "0.8rem",
         "fontWeight": 400,
       }
@@ -15793,7 +15793,7 @@ exports[`Snapshots Text thin 1`] = `
     style={
       Object {
         "color": "#59626a",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 300,
       }
@@ -15810,7 +15810,7 @@ exports[`Snapshots Text torchRed 1`] = `
     style={
       Object {
         "color": "#ff1e1e",
-        "fontFamily": "\\"Open Sans\\" sans-serif",
+        "fontFamily": "\\"Open Sans\\", sans-serif",
         "fontSize": "1rem",
         "fontWeight": 400,
       }
@@ -15834,7 +15834,7 @@ exports[`Snapshots Text white 1`] = `
       style={
         Object {
           "color": "#fff",
-          "fontFamily": "\\"Open Sans\\" sans-serif",
+          "fontFamily": "\\"Open Sans\\", sans-serif",
           "fontSize": "1rem",
           "fontWeight": 400,
         }

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -9987,7 +9987,6 @@ exports[`Snapshots InputTime default 1`] = `
       onChange={[Function]}
       style={
         Object {
-          "display": "inline-flex",
           "marginRight": "0.25rem",
         }
       }
@@ -10407,7 +10406,6 @@ exports[`Snapshots InputTime disabled 1`] = `
       onChange={[Function]}
       style={
         Object {
-          "display": "inline-flex",
           "marginRight": "0.25rem",
         }
       }
@@ -10855,7 +10853,6 @@ exports[`Snapshots InputTime noStyle 1`] = `
           "WebkitAppearance": "none",
           "background": "transparent",
           "border": 0,
-          "display": "inline-flex",
           "margin": 0,
           "marginRight": "0.25rem",
           "padding": 0,
@@ -12217,7 +12214,6 @@ exports[`Snapshots InputTime with afternoon value set 1`] = `
       onChange={[Function]}
       style={
         Object {
-          "display": "inline-flex",
           "marginRight": "0.25rem",
         }
       }
@@ -13095,7 +13091,6 @@ exports[`Snapshots InputTime with form submitting 1`] = `
       onChange={[Function]}
       style={
         Object {
-          "display": "inline-flex",
           "marginRight": "0.25rem",
         }
       }
@@ -13515,7 +13510,6 @@ exports[`Snapshots InputTime with value set 1`] = `
       onChange={[Function]}
       style={
         Object {
-          "display": "inline-flex",
           "marginRight": "0.25rem",
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.5.17-beta.1",
+  "version": "0.5.17-beta.2",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.5.16",
+  "version": "0.5.17-beta.1",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "0.5.17-beta.2",
+  "version": "0.5.16",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {

--- a/style/font.js
+++ b/style/font.js
@@ -1,4 +1,4 @@
-export const fontFamily = '"Open Sans" sans-serif';
+export const fontFamily = '"Open Sans", sans-serif';
 
 export const fontSize = '1rem';
 export const fontSizeLarge = '2rem';


### PR DESCRIPTION
### Purpose
This PR removes `inline-flex` from our `default` style on `InputTime` to safeguard future issues we might have. We also had a missing `,` in our `fontFamily` value that broke the font rendering in buffer-web using our `Text` component.
### Things to Note
We might want to update `package.json` before we merge this one to `master`. 👍
### Review
Keen to see how this feels!