### PR TITLE
Patch/input time ampm

### DIFF
--- a/InputTime/index.jsx
+++ b/InputTime/index.jsx
@@ -36,8 +36,8 @@ const renderAmPm = ({
       onChange={e => onChange({
         ...value,
         hours: e.target.value === 'AM'
-        ? value.hours - 12
-        : value.hours + 12,
+        ? parseInt(value.hours, 10) - 12
+        : parseInt(value.hours, 10) + 12,
       })}
       style={style}
       value={value.hours < 12 ? 'AM' : 'PM'}

--- a/InputTime/story.jsx
+++ b/InputTime/story.jsx
@@ -70,7 +70,7 @@ storiesOf('InputTime')
       input={{
         onChange: action('on-change'),
         value: {
-          hours: 11,
+          hours: 15,
           minutes: 32,
         },
       }}

--- a/__snapshots__/snapshot.test.js.snap
+++ b/__snapshots__/snapshot.test.js.snap
@@ -12618,65 +12618,65 @@ exports[`Snapshots InputTime with afternoon value set 1`] = `
           "marginRight": "0.25rem",
         }
       }
-      value={11}
+      value={15}
     >
       <option
-        value={0}
+        value={12}
       >
         12
       </option>
       <option
-        value={1}
+        value={13}
       >
         01
       </option>
       <option
-        value={2}
+        value={14}
       >
         02
       </option>
       <option
-        value={3}
+        value={15}
       >
         03
       </option>
       <option
-        value={4}
+        value={16}
       >
         04
       </option>
       <option
-        value={5}
+        value={17}
       >
         05
       </option>
       <option
-        value={6}
+        value={18}
       >
         06
       </option>
       <option
-        value={7}
+        value={19}
       >
         07
       </option>
       <option
-        value={8}
+        value={20}
       >
         08
       </option>
       <option
-        value={9}
+        value={21}
       >
         09
       </option>
       <option
-        value={10}
+        value={22}
       >
         10
       </option>
       <option
-        value={11}
+        value={23}
       >
         11
       </option>
@@ -13001,7 +13001,7 @@ exports[`Snapshots InputTime with afternoon value set 1`] = `
           "marginRight": "0.25rem",
         }
       }
-      value="AM"
+      value="PM"
     >
       <option
         value="AM"


### PR DESCRIPTION
Hey there @hharnisc & @stevemdixon,

would like your eyes on this change. When a passing a string as the value for InputTime hour select, when plussing a string with an int, `value.hours + 12` it converts it to a string. For minus it works :) One of those JS oddities.

This became an issue when you changed from PM to AM. It dispatched the wrong change.

I'm making sure we parse back into an integer.

Also, I updated the story for InputTime for afternoon set. It had the wrong value.