### PR TITLE
Use flexbox to center Popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.4 (May 16, 2018)
+
+- Use flexbox to center the `Popover` to avoid blurry rendering from the transform.
+
 ## 2.1.3 (December 13, 2017)
 
 - Reset font `mini` to `0.9rem` and remove `0.5rem` duplicate

--- a/Popover/index.jsx
+++ b/Popover/index.jsx
@@ -29,9 +29,15 @@ const Popover = ({
           zIndex: modal,
         },
         center: {
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
+          top: '0',
+          left: '0',
+          position: 'absolute',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100vh',
+          width: '100vw',
+          justifyContent: 'center',
+          alignItems: 'center',
         },
       }, {
         center: !(left || top || bottom || right),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Purpose

Use flexbox, as the transform was causing some blurry rendering (probably not as noticeable on Retina, but I really noticed it on my non-Retina monitor)

### Things to Note

### Review

**Some aspects to consider during review:**
* Functionality and implementation
* Architecture and performance
* Code readability and style

_A friendly reminder to add a reviewer/reviewers, add an assignee (yourself if you've worked on the change), set the code review status, and set the component request. :smile:_
