### PR TITLE
Don't require children for Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.1 (June 27, 2018)
+
+- Fix `Input` to not use/require `children`.
+
 ## 2.2.0 (June 26, 2018)
 
 - Add `InputStateless` and modify `Input` so that the focus styling works

--- a/Input/index.jsx
+++ b/Input/index.jsx
@@ -4,19 +4,16 @@ import PseudoClassComponent from '../PseudoClassComponent';
 
 class Input extends PseudoClassComponent {
   render() {
-    const { children, ...rest } = this.props;
     return (
       <InputStateless
-        {...rest}
+        {...this.props}
         hovered={this.state.hovered}
         focused={this.state.focused}
         onMouseEnter={() => this.handleMouseEnter()}
         onMouseLeave={() => this.handleMouseLeave()}
         onFocus={() => this.handleFocus()}
         onBlur={() => this.handleBlur()}
-      >
-        {children}
-      </InputStateless>
+      />
     );
   }
 }

--- a/PseudoClassComponent/index.jsx
+++ b/PseudoClassComponent/index.jsx
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 
 export default class PseudoClassComponent extends Component {
   static propTypes = {
-    children: PropTypes.node.isRequired,
+    children: PropTypes.node,
+  }
+  static defaultProps = {
+    children: null,
   }
   constructor() {
     super();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Small fix to not throw prop warning.



**Some aspects to consider during review:**
* Functionality and implementation
* Architecture and performance
* Code readability and style

_A friendly reminder to add a reviewer/reviewers, add an assignee (yourself if you've worked on the change), set the code review status, and set the component request. :smile:_