### PR TITLE
Fix icon missing export and update version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.8 (October 8, 2018)
+- Fix missing export of `CircleInstReminderIcon` component.
+
 ## 2.3.7 (October 4, 2018)
 - Add `CircleInstReminderIcon` component.
 

--- a/Icon/Icons/index.js
+++ b/Icon/Icons/index.js
@@ -26,6 +26,7 @@ export CircleCheckmarkIcon from './CircleCheckmarkIcon';
 export CircleFacebookIcon from './CircleFacebookIcon';
 export CircleGooglePlusIcon from './CircleGooglePlusIcon';
 export CircleInstagramIcon from './CircleInstagramIcon';
+export CircleInstReminderIcon from './CircleInstReminderIcon';
 export CircleLinkedInIcon from './CircleLinkedInIcon';
 export CircleMinusIcon from './CircleMinusIcon';
 export CirclePinterestIcon from './CirclePinterestIcon';

--- a/Icon/how-to-add-icon.md
+++ b/Icon/how-to-add-icon.md
@@ -1,0 +1,57 @@
+# How to add a new Icon
+
+## Naming
+
+Names of icons are written in Start Case (all words capitalised) and always end in "Icon". Example: `ArrowLeftIcon`
+
+## Adding a new Icon
+
+1. **Create a new Icon component** on `Icon/Icons/` that extends Icon props:
+Example of adding `NewIcon.jsx`: 
+```js
+import React from 'react';
+import Icon from '../../Icon';
+
+const NewIcon = ({ color, size }) =>
+  <Icon color={color} size={size}>
+    <path  />
+  </Icon>;
+
+NewIcon.propTypes = {
+  ...Icon.propTypes,
+};
+
+export default NewIcon;
+```
+
+2. **Add NewIcon's export path** on `Icon/Icons/index.jsx`:
+```js
+export NewIcon from './NewIcon';
+```
+
+This will allow to use a shorter path when importing
+```js
+import { NewIcon } from '@bufferapp/components';
+```
+
+instead of 
+```js
+import NewIcon from '@bufferapp/components/Icon/Icons/NewIcon';
+```
+
+thanks to `buffer-components/index.js`: 
+```js
+export * from './Icon/Icons'
+```
+
+3. **Add a story for the NewIcon** on `Icon/story.jsx`
+```js
+import NewIcon from './Icons/NewIcon';
+  
+.add('NewIcon', () => (
+   <NewIcon />
+))
+
+```
+
+4. **You're done** :tada: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/components",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "A shared set of UI Components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Purpose
Add missing import on Instagram Reminder Icon that allows to directly import from `@bufferapp/components'` with `export * from './Icon/Icons'`