### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://travis-ci.org/bufferapp/buffer-components.svg?branch=master)](https://travis-ci.org/bufferapp/buffer-components)
 
+🚧 Legacy Buffer Components [DEPRECATED]
+
+🚧 Many of these components are still used across Buffer and its products, however they are all deprecated/unmaintained. Please use Popcorn for the latest and greatest components based on Radix/UI.
+
 A shared set of UI Components using React and CSS Modules.
 
 Demo: https://bufferapp.github.io/buffer-components/


### PR DESCRIPTION
### Purpose
The purpose of this merge request (MR) is to add a deprecation warning to the Buffer Components repository. This is important to inform users that the repository is deprecated and no longer maintained. Users are encouraged to transition to the Popcorn library for the latest components based on Radix/UI.

### Things to Note
Deprecation Warning: The message being added is:

🚧 Legacy Buffer Components [DEPRECATED]

🚧 Many of these components are still used across Buffer and its products, however they are all deprecated/unmaintained. Please use Popcorn for the latest and greatest components based on Radix/UI.

**Impact**: This change does not affect the existing code or functionality of the repository; it simply adds a visible notice for current and future users.

### Review

**Some aspects to consider during review:**
* Functionality and implementation: Not applicable, as this change is purely informational.
* Architecture and performance: Not applicable, as this change is purely informational.
* Code readability and style: Not applicable, as this change is purely informational.

_A friendly reminder to add a reviewer/reviewers, add an assignee (yourself if you've worked on the change), set the code review status, and set the component request. :smile:_
